### PR TITLE
Add additional colors to syntax-variables

### DIFF
--- a/index.less
+++ b/index.less
@@ -26,15 +26,15 @@
   .gutter .line-number.folded,
   .gutter .line-number:after,
   .fold-marker:after {
-    color: #e87b00;
+    color: @syntax-gutter-text-color-folded;
   }
 
   .invisible {
-    color: #555;
+    color: @syntax-invisible-text-color;
   }
 
   .selection .region {
-    background-color: #e1e1e1;
+    background-color: @syntax-selection-background-color;
   }
 
   &.is-focused {
@@ -54,37 +54,37 @@
 
   // Markdown
   .source.gfm {
-    color: #444;
+    color: @syntax-markdown-color;
   }
 
   .gfm {
     .markup.heading {
-      color: #111;
+      color: @syntax-markdown-heading-color;
     }
 
     & .link {
-      color: #888;
+      color: @syntax-markdown-link-color;
     }
 
     .variable.list {
-      color: #888;
+      color: @syntax-markdown-list-color;
     }
   }
 
   .markdown {
     .paragraph {
-      color: #444;
+      color: @syntax-markdown-paragraph-color;
     }
 
     .heading {
-      color: #111;
+      color: @syntax-markdown-heading-color;
     }
 
     .link {
-      color: #888;
+      color: @syntax-markdown-link-color;
 
       .string {
-        color: #888;
+        color: @syntax-markdown-link-color;
       }
     }
   }
@@ -99,131 +99,134 @@
 }
 
 .comment {
-  color: #999988;
+  color: @syntax-comment-color;
   font-style: italic;
 }
 
 .string {
-  color: #D14;
+  color: @syntax-string-color;
 }
 
 // String interpolation in Ruby, CoffeeScript, and others
 .source .string {
   .source,
   .meta.embedded.line {
-    color: #5A5A5A;
+    color: @syntax-meta-color;
   }
 
   .punctuation.section.embedded {
-    color: #920B2D;
+    color: @syntax-punctuation-color;
 
     .source {
-      color: #920B2D;  // Required for the end of embedded strings in Ruby #716
+      color: @syntax-punctuation-color;  // Required for the end of embedded strings in Ruby #716
     }
   }
 }
 
 .constant {
   &.numeric {
-    color: #D14;
+    color: @syntax-constant-numeric-color;
   }
 
   &.language {
-    color: #606aa1;
+    color: @syntax-constant-language-color;
   }
 
   &.character,
   &.other {
-    color: #606aa1;
+    color: @syntax-constant-character-color;
   }
 
   &.symbol {
-    color: #990073;
+    color: @syntax-constant-symbol-color;
   }
 
   &.numeric.line-number.find-in-files .match {
-    color: rgba(143, 190, 0, 0.63);
+    color: @syntax-constant-line-number-match;
   }
 }
 
 .variable {
-  color: #008080;
+  color: @syntax-variables-text-color;
 
   &.parameter {
-    color: #606aa1;
+    color: @syntax-variables-parameter-text-color;
   }
 }
 
 // Keywords
 .keyword {
-  color: #222;
+  color: @syntax-keyword-color;
   font-weight: bold;
 
   &.unit {
-    color: #445588;
+    color: @syntax-keyword-unit-color;
   }
 
   &.special-method {
-    color: #0086B3;
+    color: @syntax-keyword-special-method-color;
   }
 }
 
 .storage {
-  color: #222;
+  color: @syntax-storage-color;
 
   &.type {
-    color: #222;
+    color: @syntax-storage-type-color;
   }
 }
 
 .entity {
   &.name.class {
     text-decoration: underline;
-    color: #606aa1;
+    color: @syntax-entity-name-color;
   }
 
   &.other.inherited-class {
     text-decoration: underline;
-    color: #606aa1;
+    color: @syntax-entity-inherited-color;
   }
 
   &.name.function {
-    color: #900;
+    color: @syntax-entity-function-color;
   }
 
   &.name.tag {
-    color: #008080;
+    color: @syntax-entity-tag-color;
   }
 
   &.other.attribute-name {
-    color: #458;
+    color: @syntax-entity-attribute-color;
     font-weight: bold;
   }
 
   &.name.filename.find-in-files {
-    color: #E6DB74;
+    color: @syntax-entity-filename-color;
   }
 }
 
 .support {
-  &.constant,
-  &.function,
-  &.type {
-    color: #458;
+  &.constant {
+    color: @syntax-support-constant-color;
   }
-
+  &.function {
+    color: @syntax-support-function-color;
+  }
+  &.type {
+    color: @syntax-support-type-color;
+  }
   &.class {
-    color: #008080;
+    color: @syntax-support-class-color;
   }
 }
 
 .invalid {
-  color: #F8F8F0;
-  background-color: #00A8C6;
+  color: @syntax-invalid-color;
+  background-color: @syntax-invalid-background-color;
 
   &.deprecated {
-    color: #F8F8F0;
-    background-color: #8FBE00;
+    color: @syntax-invalid-deprecated-color;
+    background-color: @syntax-invalid-deprecated-background-color;
   }
 }
 
@@ -231,16 +234,16 @@
 .meta {
   &.structure.dictionary.json > .string.quoted.double.json,
   &.structure.dictionary.json > .string.quoted.double.json .punctuation.string {
-    color: #000080;
+    color: @syntax-meta-dictionary-color;
   }
 
   &.structure.dictionary.value.json > .string.quoted.double.json {
-    color: #d14;
+    color: @syntax-meta-dictionary-value-color;
   }
 
   &.diff,
   &.diff.header {
-    color: #75715E;
+    color: @syntax-diff-color;
   }
 }
 
@@ -248,17 +251,17 @@
 .css {
   &.support.property-name {
     font-weight: bold;
-    color: #333;
+    color: @syntax-css-support-color;
   }
 
   &.constant {
-    color: #099;
+    color: @syntax-css-constant-color;
   }
 }
 
 
 .bracket-matcher {
-  background-color: #C9C9C9;
+  background-color: @syntax-bracket-matcher-background-color;
   opacity: .7;
   border-bottom: 0 none;
 }

--- a/stylesheets/syntax-variables.less
+++ b/stylesheets/syntax-variables.less
@@ -3,9 +3,12 @@
 
 // General colors
 @syntax-text-color: #555;
+@syntax-invisible-text-color: #555;
 @syntax-cursor-color: black;
 @syntax-selection-color: #afc4da;
+@syntax-selection-background-color: #e1e1e1;
 @syntax-background-color: white;
+@syntax-bracket-matcher-background-color: #C9C9C9;
 
 // Guide colors
 @syntax-wrap-guide-color: rgba(85, 85, 85, .2);
@@ -19,11 +22,74 @@
 // Gutter colors
 @syntax-gutter-text-color: @syntax-text-color;
 @syntax-gutter-text-color-selected: @syntax-gutter-text-color;
+@syntax-gutter-text-color-folded: #e87b00;
 @syntax-gutter-background-color: white;
 @syntax-gutter-background-color-selected: rgba(255, 255, 134, 0.34);
+
+// Variables
+@syntax-variables-text-color: #008080;
+@syntax-variables-parameter-text-color: #606aa1;
 
 // For git diff info. i.e. in the gutter
 @syntax-color-renamed: #96CBFE;
 @syntax-color-added: #718C00;
 @syntax-color-modified: #ff982d;
 @syntax-color-removed: #D14;
+
+// Markdown
+@syntax-markdown-color: #444;
+@syntax-markdown-heading-color: #111;
+@syntax-markdown-link-color: #888;
+@syntax-markdown-list-color: #888;
+@syntax-markdown-paragraph-color: #444;
+
+// String and comment colors
+@syntax-comment-color: #999988;
+@syntax-string-color: #D14;
+@syntax-meta-color: #5A5A5A;
+@syntax-punctuation-color: #920B2D;
+
+// Constants
+@syntax-constant-numeric-color: #D14;
+@syntax-constant-language-color: #606aa1;
+@syntax-constant-character-color: #606aa1;
+@syntax-constant-symbol-color: #990073;
+@syntax-constant-line-number-match: rgba(143, 190, 0, 0.63);
+
+// Keyword
+@syntax-keyword-color: #222;
+@syntax-keyword-unit-color: #445588;
+@syntax-keyword-special-method-color: #0086B3;
+
+// Storage
+@syntax-storage-color: #222;
+@syntax-storage-type-color: #222;
+
+// Entity
+@syntax-entity-name-color: #606aa1;
+@syntax-entity-inherited-color: #606aa1;
+@syntax-entity-function-color: #900
+@syntax-entity-tag-color: #008080;
+@syntax-entity-attribute-color: #458;
+@syntax-entity-filename-color: #E6DB74;
+
+// Support
+@syntax-support-constant-color: #458;
+@syntax-support-function-color: #458;
+@syntax-support-type-color: #458;
+@syntax-support-class-color: #008080;
+
+// Invalid
+@syntax-invalid-color: #F8F8F0;
+@syntax-invalid-background-color: #00A8C6;
+@syntax-invalid-deprecated-color: #F8F8F0;
+@syntax-invalid-deprecated-background-color: #8FBE00;
+
+// Meta
+@syntax-meta-dictionary-color: #000080;
+@syntax-meta-dictionary-value-color: #d14;
+@syntax-diff-color: #75715E;
+
+// CSS
+@syntax-css-support-color: #333;
+@syntax-css-constant-color: #099;


### PR DESCRIPTION
This moves additional color variables over to `syntax-variables.less` to help clean up the CSS a bit more.
