### PR TITLE
Fix highlighting of interpolated strings in .html.erb files

### DIFF
--- a/index.less
+++ b/index.less
@@ -100,7 +100,7 @@
 }
 
 // String interpolation in Ruby, CoffeeScript, and others
-.source .string {
+.string {
   .source,
   .meta.embedded.line {
     color: #5A5A5A;


### PR DESCRIPTION
In code like:

``` html+erb
<a href="<%= link_to :whatever %>">
```

the scope that contains the ERB tags is a `.text .string` scope, not a `.source .string` scope like our styles were expecting.

We now don't care about any scopes outside of the string itself when detecting string interpolation. If there is source code inside a string, it is considered to be interpolation, no matter where that string lives.
