### PR TITLE
Language variables

### DIFF
--- a/index.less
+++ b/index.less
@@ -152,7 +152,7 @@ atom-text-editor, :host {
 }
 
 .variable {
-  color: @syntax-color-variable;
+  color: #008080;
 
   &.parameter {
     color: #606aa1;
@@ -161,7 +161,7 @@ atom-text-editor, :host {
 
 // Keywords
 .keyword {
-  color: @syntax-color-keyword;
+  color: #222;
   font-weight: bold;
 
   &.unit {
@@ -184,24 +184,24 @@ atom-text-editor, :host {
 .entity {
   &.name.class {
     text-decoration: underline;
-    color: @syntax-color-class;
+    color: #606aa1;
   }
 
   &.other.inherited-class {
     text-decoration: underline;
-    color: @syntax-color-class;
+    color: #606aa1;
   }
 
   &.name.function {
-    color: @syntax-color-function;
+    color: #900;
   }
 
   &.name.tag {
-    color: @syntax-color-tag;
+    color: #008080;
   }
 
   &.other.attribute-name {
-    color: @syntax-color-attribute;
+    color: #458;
     font-weight: bold;
   }
 
@@ -253,11 +253,11 @@ atom-text-editor, :host {
 .css {
   &.support.property-name {
     font-weight: bold;
-    color: @syntax-color-property;
+    color: #333;
   }
 
   &.constant {
-    color: @syntax-color-constant;
+    color: #099;
   }
 }
 

--- a/index.less
+++ b/index.less
@@ -152,7 +152,7 @@ atom-text-editor, :host {
 }
 
 .variable {
-  color: #008080;
+  color: @syntax-color-variable;
 
   &.parameter {
     color: #606aa1;
@@ -161,7 +161,7 @@ atom-text-editor, :host {
 
 // Keywords
 .keyword {
-  color: #222;
+  color: @syntax-color-keyword;
   font-weight: bold;
 
   &.unit {
@@ -184,24 +184,24 @@ atom-text-editor, :host {
 .entity {
   &.name.class {
     text-decoration: underline;
-    color: #606aa1;
+    color: @syntax-color-class;
   }
 
   &.other.inherited-class {
     text-decoration: underline;
-    color: #606aa1;
+    color: @syntax-color-class;
   }
 
   &.name.function {
-    color: #900;
+    color: @syntax-color-function;
   }
 
   &.name.tag {
-    color: #008080;
+    color: @syntax-color-tag;
   }
 
   &.other.attribute-name {
-    color: #458;
+    color: @syntax-color-attribute;
     font-weight: bold;
   }
 
@@ -253,11 +253,11 @@ atom-text-editor, :host {
 .css {
   &.support.property-name {
     font-weight: bold;
-    color: #333;
+    color: @syntax-color-property;
   }
 
   &.constant {
-    color: #099;
+    color: @syntax-color-constant;
   }
 }
 

--- a/styles/syntax-variables.less
+++ b/styles/syntax-variables.less
@@ -28,3 +28,17 @@
 @syntax-color-added: #718C00;
 @syntax-color-modified: #ff982d;
 @syntax-color-removed: #D14;
+
+// For language entity colors
+@syntax-color-variable: #008080;
+@syntax-color-constant: #099;
+@syntax-color-property: #333;
+@syntax-color-value: @syntax-color-constant;
+@syntax-color-function: #900;
+@syntax-color-method: @syntax-color-function;
+@syntax-color-class: #606aa1;
+@syntax-color-keyword: #222;
+@syntax-color-tag: #008080;
+@syntax-color-attribute: #458;
+@syntax-color-import: @syntax-color-keyword;
+@syntax-color-snippet: @syntax-color-constant;


### PR DESCRIPTION
This PR adds language variables used by Autocomplete plus https://github.com/atom-community/autocomplete-plus/issues/351

Not quite sure about the `@syntax-color-snippet` variable. Currently mapped to `@syntax-color-constant`.